### PR TITLE
Add FI_READ and FI_WRITE to access flags.  Fix typo in error message.

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_module.c
+++ b/opal/mca/btl/ofi/btl_ofi_module.c
@@ -186,7 +186,7 @@ static int mca_btl_ofi_deregister_mem (mca_btl_base_module_t *btl, mca_btl_base_
 int mca_btl_ofi_reg_mem (void *reg_data, void *base, size_t size, mca_rcache_base_registration_t *reg)
 {
     int rc;
-    static uint64_t access_flags = FI_REMOTE_WRITE | FI_REMOTE_READ;
+    static uint64_t access_flags = FI_REMOTE_WRITE | FI_REMOTE_READ | FI_READ | FI_WRITE;
 
     mca_btl_ofi_module_t *btl = (mca_btl_ofi_module_t*) reg_data;
     mca_btl_ofi_reg_t *ur = (mca_btl_ofi_reg_t*) reg;

--- a/opal/mca/btl/ofi/btl_ofi_rdma.c
+++ b/opal/mca/btl/ofi/btl_ofi_rdma.c
@@ -78,7 +78,7 @@ int mca_btl_ofi_get (mca_btl_base_module_t *btl, mca_btl_base_endpoint_t *endpoi
         return OPAL_ERR_OUT_OF_RESOURCE;
 
     if (0 != rc) {
-        BTL_ERROR(("fi_write failed with %d:%s", rc, fi_strerror(-rc)));
+        BTL_ERROR(("fi_read failed with %d:%s", rc, fi_strerror(-rc)));
         abort();
     }
 


### PR DESCRIPTION
Leave a comment