### PR TITLE
btl/ofi: fixes for GNI provider

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi.h
+++ b/opal/mca/btl/ofi/btl_ofi.h
@@ -125,7 +125,7 @@ typedef struct mca_btl_ofi_component_t mca_btl_ofi_component_t;
 OPAL_MODULE_DECLSPEC extern mca_btl_ofi_component_t mca_btl_ofi_component;
 
 struct mca_btl_base_registration_handle_t {
-    uint32_t rkey;
+    uint64_t rkey;
     void *desc;
     void *base_addr;
 };

--- a/opal/mca/btl/ofi/btl_ofi_providers.h
+++ b/opal/mca/btl/ofi/btl_ofi_providers.h
@@ -1,6 +1,8 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2018      Intel, Inc, All rights reserved
+ * Copyright (c) 2018      Los Alamos National Security, LLC. All rights
+ *                         reserved.
  *
  * $COPYRIGHT$
  *
@@ -22,6 +24,7 @@ static void provider_hints_handler(struct fi_info *hints);
 static int validate_info(struct fi_info *info);
 static int socks_validate_info(struct fi_info *info);
 static int psm2_validate_info(struct fi_info *info);
+static int gni_validate_info(struct fi_info *info);
 
 
 /* functions below */
@@ -33,6 +36,12 @@ static int socks_validate_info(struct fi_info *info)
 }
 
 static int psm2_validate_info(struct fi_info *info)
+{
+    /* placeholder */
+    return OPAL_SUCCESS;
+}
+
+static int gni_validate_info(struct fi_info *info)
 {
     /* placeholder */
     return OPAL_SUCCESS;
@@ -65,6 +74,8 @@ static int validate_info(struct fi_info *info)
         return socks_validate_info(info);
     } else if (!strcmp(prov_name, "psm2")) {
         return psm2_validate_info(info);
+    } else if (!strcmp(prov_name, "gni")) {
+        return gni_validate_info(info);
     }
 
     return OPAL_SUCCESS;
@@ -73,6 +84,15 @@ static int validate_info(struct fi_info *info)
 /* fill out specific hints needed for each provider */
 static void provider_hints_handler(struct fi_info *hints)
 {
-    /* placeholder for providers to modify their hints */
-    //char *prov_name = hints->fabric_attr->prov_name;
+    char *prov_name;
+
+    assert(hints->fabric_attr);
+    assert(hints->domain_attr);
+    assert(hints->fabric_attr->prov_name);
+
+    prov_name = hints->fabric_attr->prov_name;
+
+    if (!strcmp(prov_name, "gni")) {
+        hints->domain_attr->mr_mode = FI_MR_BASIC;
+    }
 }


### PR DESCRIPTION
there were a few problems that were keeping the GNI
provider from working.  With these fixes, OSC/RDMA/GNI
passes all of the ibm-tests/onesided except for
1sided and mt_1sided (seg fault at end of runs) as
well as passing OSU one-sided get/put latency, bw, and bibw
tests.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>