### PR TITLE
btl/ofi: fix for GNI provider when using SEPs

### DIFF
--- a/opal/mca/btl/ofi/btl_ofi_endpoint.c
+++ b/opal/mca/btl/ofi/btl_ofi_endpoint.c
@@ -229,6 +229,15 @@ mca_btl_ofi_context_t *mca_btl_ofi_context_alloc_scalable(struct fi_info *info,
             goto scalable_fail;
         }
 
+        rc = fi_enable(contexts[i].tx_ctx);
+        if (0 != rc) {
+            BTL_VERBOSE(("%s failed fi_enable with err=%s",
+                            linux_device_name,
+                            fi_strerror(-rc)
+                            ));
+            goto scalable_fail;
+        }
+
          /* assign the id */
         contexts[i].context_id = i;
 


### PR DESCRIPTION
The GNI provider requires that tx ctx's allocated
from an SEP be enabled prior to being used for
send/rma/amo operations.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>